### PR TITLE
Fixing bugs

### DIFF
--- a/mkexeshortcut.desktop
+++ b/mkexeshortcut.desktop
@@ -65,7 +65,7 @@ Name[vi]=Tạo lối tắt trên màn hình
 Name[zh]=創建桌面快捷方式
 
 [Desktop Action mkExeShortcut]
-Exec=$HOME/.local/share/kservices5/mkexeshortcut/mkexeshortcut.sh "%u" $PWD
+Exec=$HOME/.local/share/kservices5/mkexeshortcut/mkexeshortcut.sh "%u" "$PWD"
 Icon=insert-link
 Name=Create shortcut here
 Name[ar]=إنشاء اختصار هنا

--- a/mkexeshortcut.sh
+++ b/mkexeshortcut.sh
@@ -15,7 +15,7 @@ if [[ $# < 1 ]]; then
     exit 5
 fi
 
-input=$1
+input="$1"
 
 if ( file --mime-type "$input" | grep -o "application/x-dosexec" >/dev/null ); then
     echo -e "\e[1m\e[1;33mWorking on file:\e[0m \e[3m\e[96m\"$input\"\e[0m\e[1m\e[1;33m."
@@ -34,11 +34,18 @@ fi
 input_filename=${input##*/}
 input_title=$(echo ${input_filename%.exe} | sed -s "s/_/ /g")
 
-output="$HOME/Desktop/$input_title.desktop"
+# Search for user's desktop
+desktop="$HOME/Desktop"
+if [[ -n "$(xdg-user-dir DESKTOP)" ]]
+then
+    desktop="$(xdg-user-dir DESKTOP)"
+fi
+
+output="$desktop/$input_title.desktop"
 
 if [ $# == 2 ]; then
-    if [ -d $2 ]; then
-        if [ -w $2 ]; then
+    if [ -d "$2" ]; then
+        if [ -w "$2" ]; then
             output="$2/$input_title.desktop"
         else
             echo -e "\e[1m\e[31mERROR: Folder is not writable:\e[0m \e[3m\e[96m\"$2\"\e[0m\e[1m\e[31m."


### PR DESCRIPTION
Paths should be inserted in quotes and user's desktop location may be somewhere else than "$HOME/Desktop" depending on the user's settings and/or system language

For example, my desktop is on _"/home/joseskvolpe/Área de Trabalho"_ instead of _"/home/joseskvolpe/Desktop"_. So using the shortcut would give me:
>./mkexeshortcut.sh: line 121: /home/joseskvolpe/Desktop/CLIPStudioPaint.desktop: No such file or directory
ERROR: The file "/home/joseskvolpe/Desktop/CLIPStudioPaint.desktop" could not be created.

And, without inserting quotes between locations, the script would fail to create shortcuts if the input (EXE file) is located in somewhere with a special letter or a space bar character.
So, for example, i have CLIPStudioPaint.exe located in _"/home/joseskvolpe/.wine/drive_c/Program Files/CELSYS/CLIP STUDIO 1.5/CLIP STUDIO PAINT/CLIPStudioPaint.exe"_, i get this error:

>./mkexeshortcut.sh: line 40: [: too many arguments
ERROR: Parameter is not a folder: "/home/joseskvolpe/.wine/drive_c/Program Files/CELSYS/CLIP STUDIO 1.5/CLIP STUDIO PAINT/".