### PR TITLE
Check for application/vnd.microsoft.portable-executable

### DIFF
--- a/mkexeshortcut.desktop
+++ b/mkexeshortcut.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.05
 Type=Service
-MimeType=application/x-ms-dos-executable
+MimeType=application/x-ms-dos-executable;application/vnd.microsoft.portable-executable
 Icon=insert-link
 Actions=mkExeShortcut;mkExeDesktopShortcut;
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin

--- a/mkexeshortcut.sh
+++ b/mkexeshortcut.sh
@@ -17,7 +17,7 @@ fi
 
 input="$(readlink -f "$1")"
 
-if ( file --mime-type "$input" | grep -o "application/x-dosexec" >/dev/null ); then
+if ( file --mime-type "$input" | grep -e "application/x-dosexec" -e "application/vnd.microsoft.portable-executable" >/dev/null ); then
     echo -e "\e[1m\e[1;33mWorking on file:\e[0m \e[3m\e[96m\"$input\"\e[0m\e[1m\e[1;33m.\e[0m"
 else
     echo -e "\e[1m\e[31mERROR: File is not a Windows executable:\e[0m \e[3m\e[96m\"$input\"\e[0m\e[1m\e[31m.\e[0m"


### PR DESCRIPTION
Looks like there was a change and Windows executables are identified as application/vnd.microsoft.portable-executable now